### PR TITLE
Seq minor fixes

### DIFF
--- a/parallel_esn/esn.py
+++ b/parallel_esn/esn.py
@@ -309,6 +309,8 @@ class ESN:
         Yhat : np.ndarray
             Prediction of observations.
         """
+        if not isinstance(self.W_out, np.ndarray):  # Check if W_out exists yet
+            raise UnboundLocalError('Must train network before predictions can be made.')
         W_out = self.W_out
         Yhat = np.matmul(W_out, X)
         return Yhat

--- a/parallel_esn/esn.py
+++ b/parallel_esn/esn.py
@@ -232,7 +232,7 @@ class ESN:
         Returns
         -------
         loss : float
-            Returns the sum of the losses computed on each sequence
+            Returns the average of the NMSE losses computed on each sequence
         """
         nseq = batchU.shape[0]
         loss = 0.
@@ -331,10 +331,16 @@ class ESN:
         Returns
         -------
         error : float
+            Normalized mean square error (NMSE). Each feature's NMSE is
+            computed separately and averaged together at the end.
 
         """
         Yhat = self.predict(U)
-        return mean_squared_error(Y_true, Yhat)
+        num_features = Y_true.shape[0]
+        error = 0.
+        for j in range(num_features):
+            error += mean_squared_error(Y_true[j, :], Yhat[j, :])/np.var(Y_true)
+        return error/num_features
 
     def score_with_X(self, X, Y_true):
         """
@@ -361,4 +367,8 @@ class ESN:
 
         """
         Yhat = self.predict_with_X(X)
-        return mean_squared_error(Y_true, Yhat)
+        num_features = Y_true.shape[0]
+        error = 0.
+        for j in range(num_features):
+            error += mean_squared_error(Y_true[j, :], Yhat[j, :])/np.var(Y_true)
+        return error/num_features

--- a/parallel_esn/esn.py
+++ b/parallel_esn/esn.py
@@ -331,7 +331,7 @@ class ESN:
         Returns
         -------
         error : float
-            Normalized mean square error (NMSE). Each feature's NMSE is
+            Normalized root mean square error (NRMSE). Each feature's NRMSE is
             computed separately and averaged together at the end.
 
         """
@@ -339,7 +339,8 @@ class ESN:
         num_features = Y_true.shape[0]
         error = 0.
         for j in range(num_features):
-            error += mean_squared_error(Y_true[j, :], Yhat[j, :])/np.var(Y_true)
+            error += np.sqrt(mean_squared_error(Y_true[j, :], Yhat[j, :])
+                             / np.var(Y_true))
         return error/num_features
 
     def score_with_X(self, X, Y_true):
@@ -364,11 +365,14 @@ class ESN:
         Returns
         -------
         error : float
+            Normalized mean square error (NRMSE). Each feature's NRMSE is
+            computed separately and averaged together at the end.
 
         """
         Yhat = self.predict_with_X(X)
         num_features = Y_true.shape[0]
         error = 0.
         for j in range(num_features):
-            error += mean_squared_error(Y_true[j, :], Yhat[j, :])/np.var(Y_true)
+            error += np.sqrt(mean_squared_error(Y_true[j, :], Yhat[j, :])
+                             / np.var(Y_true))
         return error/num_features

--- a/parallel_esn/esn.py
+++ b/parallel_esn/esn.py
@@ -145,7 +145,8 @@ class ESN:
         Returns
         -------
         X : np.ndarray
-            X is [1;u(n);x(n)] concatenated horizontally (n is time)
+            X is [1;u(n);x(n)] concatenated horizontally (n is time) generated
+            from input data U.
             Dimensions of (1+ N_u + N_x) x T
         """
         T = U.shape[1]
@@ -209,9 +210,8 @@ class ESN:
             self.XXt += X @ X.T
             self.YXt += batchY_true[s, :, :] @ X.T
             self._compute_Wout()
-            # Can optimize the following by having a score function that can use
-            # precomputed X instead of recomputing it from U
-            loss[s] = self.score(batchU[s, :, :], batchY_true[s, :, :])
+            # Use precomputed X instead of recomputing it from U
+            loss[s] = self.score_with_X(X, batchY_true[s, :, :])
             if verbose == 1:
                 print("loss = {}".format(loss[s]))
         return loss
@@ -238,7 +238,7 @@ class ESN:
         loss = 0.
         for s in range(nseq):
             loss += self.score(batchU[s, :, :], batchY_true[s, :, :])
-        return loss
+        return loss/nseq
 
     def train_validate(self, trainU, trainY, valU, valY, verbose=1):
         """
@@ -285,8 +285,31 @@ class ESN:
         Yhat : np.ndarray
             Prediction of observations.
         """
+        if not isinstance(self.W_out, np.ndarray):  # Check if W_out exists yet
+            raise UnboundLocalError('Must train network before predictions can be made.')
         W_out = self.W_out
         X = self._compute_X(U)
+        Yhat = np.matmul(W_out, X)
+        return Yhat
+
+    def predict_with_X(self, X):
+        """
+        Predicts Yhat, output observations, given X already generated
+        from input data U.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            X is [1;u(n);x(n)] concatenated horizontally (n is time), generated
+            from the input data U.
+            Dimensions of (1+ N_u + N_x) x T
+
+        Returns
+        -------
+        Yhat : np.ndarray
+            Prediction of observations.
+        """
+        W_out = self.W_out
         Yhat = np.matmul(W_out, X)
         return Yhat
 
@@ -309,4 +332,31 @@ class ESN:
 
         """
         Yhat = self.predict(U)
+        return mean_squared_error(Y_true, Yhat)
+
+    def score_with_X(self, X, Y_true):
+        """
+        Computes loss given input data X already processed with reservoir
+        activations. Functions identically to running:
+
+        self.score(self._compute_X(U), Y_true)
+
+        if provided X corresponds to U.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            X is [1;u(n);x(n)] concatenated horizontally (n is time), generated
+            from the input data U.
+            Dimensions of (1+ N_u + N_x) x T
+        Y_true : np.ndarray
+            Target output array,  y(n) concatenated horizontally in time.
+            Dimensions - N_y x T
+
+        Returns
+        -------
+        error : float
+
+        """
+        Yhat = self.predict_with_X(X)
         return mean_squared_error(Y_true, Yhat)

--- a/parallel_esn/tests/test_utils.py
+++ b/parallel_esn/tests/test_utils.py
@@ -73,15 +73,25 @@ def test_chunk_data_2d():
                            [7, -7]])
 
     # Test when data chunks evenly
-    chunkU1, chunkY1 = chunk_data(timeseries, 2, 4)
+    chunkU1, chunkY1 = chunk_data(timeseries, 2, 4,
+                                  predict_cols=[0, 1])
     ansU1 = np.array([[[0, 1], [0, -1]], [[4, 5], [-4, -5]]])
     ansY1 = np.array([[[2, 3], [-2, -3]], [[6, 7], [-6, -7]]])
     np.testing.assert_array_equal(chunkU1, ansU1)
     np.testing.assert_array_equal(chunkY1, ansY1)
 
     # Test when data does not chunk evenly
-    chunkU2, chunkY2 = chunk_data(timeseries, 2, 3)
+    chunkU2, chunkY2 = chunk_data(timeseries, 2, 3,
+                                  predict_cols=[0, 1])
     ansU2 = np.array([[[0, 1], [0, -1]], [[3, 4], [-3, -4]]])
     ansY2 = np.array([[[2, 3], [-2, -3]], [[5, 6], [-5, -6]]])
     np.testing.assert_array_equal(chunkU2, ansU2)
     np.testing.assert_array_equal(chunkY2, ansY2)
+
+    # Test chunking when predicting just column 0
+    chunkU3, chunkY3 = chunk_data(timeseries, 2, 4,
+                                  predict_cols=[0])
+    ansU3 = np.array([[[0, 1], [0, -1]], [[4, 5], [-4, -5]]])
+    ansY3 = np.array([[[2, 3]], [[6, 7]]])
+    np.testing.assert_array_equal(chunkU3, ansU3)
+    np.testing.assert_array_equal(chunkY3, ansY3)

--- a/parallel_esn/tests/test_utils.py
+++ b/parallel_esn/tests/test_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from ..utils import compute_spectral_radius, create_rng
+from ..utils import compute_spectral_radius, create_rng, chunk_data
 
 
 def test_compute_spectral_radius():
@@ -40,3 +40,48 @@ def test_create_rng():
     rng1 = create_rng(np.random.RandomState(17))
     bytes1 = rng1.bytes(1)
     assert bytes0 == bytes1
+
+
+def test_chunk_data_1d():
+    # Test chunking 1d data
+    timeseries = np.array([0, 1, 2, 3, 4, 5, 6, 7])
+
+    # Test when data chunks evenly
+    chunkU1, chunkY1 = chunk_data(timeseries, 2, 4)
+    ansU1 = np.array([[[0, 1]], [[4, 5]]])
+    ansY1 = np.array([[[2, 3]], [[6, 7]]])
+    np.testing.assert_array_equal(chunkU1, ansU1)
+    np.testing.assert_array_equal(chunkY1, ansY1)
+
+    # Test when data does not chunk evenly
+    chunkU2, chunkY2 = chunk_data(timeseries, 2, 3)
+    ansU2 = np.array([[[0, 1]], [[3, 4]]])
+    ansY2 = np.array([[[2, 3]], [[5, 6]]])
+    np.testing.assert_array_equal(chunkU2, ansU2)
+    np.testing.assert_array_equal(chunkY2, ansY2)
+
+
+def test_chunk_data_2d():
+    # Test chunking 2d data
+    timeseries = np.array([[0, 0],
+                           [1, -1],
+                           [2, -2],
+                           [3, -3],
+                           [4, -4],
+                           [5, -5],
+                           [6, -6],
+                           [7, -7]])
+
+    # Test when data chunks evenly
+    chunkU1, chunkY1 = chunk_data(timeseries, 2, 4)
+    ansU1 = np.array([[[0, 1], [0, -1]], [[4, 5], [-4, -5]]])
+    ansY1 = np.array([[[2, 3], [-2, -3]], [[6, 7], [-6, -7]]])
+    np.testing.assert_array_equal(chunkU1, ansU1)
+    np.testing.assert_array_equal(chunkY1, ansY1)
+
+    # Test when data does not chunk evenly
+    chunkU2, chunkY2 = chunk_data(timeseries, 2, 3)
+    ansU2 = np.array([[[0, 1], [0, -1]], [[3, 4], [-3, -4]]])
+    ansY2 = np.array([[[2, 3], [-2, -3]], [[5, 6], [-5, -6]]])
+    np.testing.assert_array_equal(chunkU2, ansU2)
+    np.testing.assert_array_equal(chunkY2, ansY2)

--- a/parallel_esn/utils.py
+++ b/parallel_esn/utils.py
@@ -91,6 +91,12 @@ def chunk_data(timeseries, windowsize, stride):
     length = timeseries.shape[0]
     # Get transposed view for later array assignment convenience
     timeseriesT = timeseries.T
+    if length < 2*windowsize:
+        raise ValueError(("Window size too large for timeseries. "
+                          "Provided timeseries has {} times, "
+                          "and provided windowsize needs at least "
+                          "2*windowsize = {} time points."
+                          .format(length, 2*windowsize)))
     num_chunks = (length - 2*windowsize)//stride + 1
     batchU = np.zeros((num_chunks, feature_len, windowsize))
     batchY = np.zeros((num_chunks, feature_len, windowsize))


### PR DESCRIPTION
Added many small fixes to the sequential version of the code. Made calculating the loss more efficient by providing scoring/predicting methods that run given an already computed X instead of recomputing it from U, extended chunk_data to work for chunking timeseries of feature vectors (instead of just single features), and changed the computed error to NRMSE like in the paper https://arxiv.org/pdf/1611.05193.pdf . 

Also added tests for new functions that have been written, and made some existing ESN tests more efficient. 