### PR TITLE
Sparse

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,6 @@ Maintainer
 Contributors
 ------------
 
-None yet. Why not be the first? See: CONTRIBUTING.rst
+* Cedric Flamant <https://github.com/cflamant>
+
+Want to be a contributor? See: CONTRIBUTING.rst

--- a/parallel_esn/utils.py
+++ b/parallel_esn/utils.py
@@ -1,14 +1,17 @@
 import numpy as np
+from scipy.sparse.linalg import eigs as sparse_eigs
 
 
-def compute_spectral_radius(X):
+def compute_spectral_radius(X, is_sparse=False):
     """
     Computes the spectral radius of a matrix
 
     Parameters
     ----------
-    X : np.ndarray
+    X : np.ndarray or scipy.sparse.csr.csr_matrix
         Input matrix
+    is_sparse : bool, optional, default=False
+        Whether the passed matrix X is a SciPy sparse matrix or not.
 
     Returns
     -------
@@ -19,8 +22,13 @@ def compute_spectral_radius(X):
     # To compute the eigen-values of a matrix, it must be square
     assert X.shape[0] == X.shape[1], print('Input matrix must be square')
 
-    eigvals = np.linalg.eigvals(X)
-    return np.max(np.abs(eigvals))
+    if is_sparse:
+        eigvec = sparse_eigs(X, k=1, which='LM', return_eigenvectors=False)
+        maxeig = np.abs(eigvec[0].real)
+    else:
+        eigvals = np.linalg.eigvals(X)
+        maxeig = np.max(np.abs(eigvals))
+    return maxeig
 
 
 def create_rng(random_state):


### PR DESCRIPTION
Add the ability to use sparse matrices for the W matrix describing neuron connections in the reservoir. This greatly improves the speed of training and predicting when the matrix is larger than about 100x100, and with a sparsity greater than 60%. Small-world networks generally have high sparsity, sometimes approaching 95%+, and this is where very substantial speedups are gained with sparse matrix operations.

Currently not compatible with the Cython implementation of calculate_X